### PR TITLE
Specify node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   },
   "devDependencies": {
     "auto": "^10.32.6"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
#### Context
Apparently react-scripts doesn't work with node that's before v14. This resulted in digital ocean's deployment in failing. I've specified the node version in which it'll work so hopefully do can properly deploy this now

#### Change
- Add node version to engine