### PR TITLE
Add scroll listeners

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,10 @@ function App() {
   const previousLocation = useRef('');
 
   useEffect(() => {
-    console.log(location);
+    if (location.pathname !== previousLocation.current) {
+      window.scrollTo(0, 0);
+      previousLocation.current = location.pathname;
+    }
   }, [location]);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,10 @@ function App() {
   const previousLocation = useRef('');
 
   useEffect(() => {
-    if (location.pathname !== previousLocation.current) {
+    if (location.pathname !== previousLocation.current && location.hash.length === 0) {
       window.scrollTo(0, 0);
-      previousLocation.current = location.pathname;
     }
+    previousLocation.current = location.pathname;
   }, [location]);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,19 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import WorkInProgress from './app/components/WorkInProgress';
 import TermsContainer from './app/components/TermsContainer';
 import NavBar from './app/components/NavBar';
 import Footer from './app/components/Footer';
 import styles from './App.module.scss';
+import { useEffect, useRef } from 'react';
 
 function App() {
+  const location = useLocation();
+  const previousLocation = useRef('');
+
+  useEffect(() => {
+    console.log(location);
+  }, [location]);
+
   return (
     <div className={styles.App}>
       <NavBar />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,10 @@ function App() {
   const location = useLocation();
   const previousLocation = useRef('');
 
+  /**
+   * Handler to scroll to beginning of page
+   * Occurs every time a location changes unless it's the same page/there's a hash param
+   */
   useEffect(() => {
     if (location.pathname !== previousLocation.current && location.hash.length === 0) {
       window.scrollTo(0, 0);

--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -49,7 +49,7 @@ export default function Footer() {
           <Link to="/terms_and_privacy#terms_of_use" className={styles.LinkName}>
             Terms of Use
           </Link>
-          <Link to="/terms_and_privacy#privacy_policy" className={styles.LinkName}>
+          <Link to="/terms_and_privacy#introduction" className={styles.LinkName}>
             Privacy Policy
           </Link>
           <Link to="/" className={styles.LinkName}>

--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -46,10 +46,10 @@ export default function Footer() {
         </div>
         <div className={styles.About}>
           <div className={styles.LinkTitle}>About</div>
-          <Link to="/terms_and_privacy" className={styles.LinkName}>
+          <Link to="/terms_and_privacy#terms_of_use" className={styles.LinkName}>
             Terms of Use
           </Link>
-          <Link to="/terms_and_privacy" className={styles.LinkName}>
+          <Link to="/terms_and_privacy#privacy_policy" className={styles.LinkName}>
             Privacy Policy
           </Link>
           <Link to="/" className={styles.LinkName}>

--- a/src/app/components/NavBar/index.tsx
+++ b/src/app/components/NavBar/index.tsx
@@ -1,6 +1,7 @@
 import styles from './NavBar.module.scss';
 import Button from '../Elements/Button';
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 export default function NavBar() {
   const [scroll, setScroll] = useState(0);
@@ -13,10 +14,12 @@ export default function NavBar() {
   });
   return (
     <div className={`${styles.Container} ${scroll > 10 && styles.Scrolling}`}>
-      <div className={styles.Title}>
-        <img src="./nessie_logo.png" alt="Nessie Logo" className={styles.Logo} />
-        <div className={styles.Name}>nessie</div>
-      </div>
+      <Link to="/">
+        <div className={styles.Title}>
+          <img src="./nessie_logo.png" alt="Nessie Logo" className={styles.Logo} />
+          <div className={styles.Name}>nessie</div>
+        </div>
+      </Link>
       <div className={styles.Links}>
         <a
           href="https://discord.com/invite/47Ccgz9jA4"

--- a/src/app/components/TermsContainer/Introduction/index.tsx
+++ b/src/app/components/TermsContainer/Introduction/index.tsx
@@ -2,7 +2,7 @@ import styles from './Introduction.module.scss';
 
 export default function Introduction() {
   return (
-    <div className={styles.Section}>
+    <div className={styles.Section} id="introduction">
       <div className={styles.Title}>Introduction</div>
       <div className={styles.Description}>
         <p>Last Updated: 15 June 2022</p>

--- a/src/app/components/TermsContainer/PrivacyPolicy/index.tsx
+++ b/src/app/components/TermsContainer/PrivacyPolicy/index.tsx
@@ -2,7 +2,7 @@ import styles from './PrivacyPolicy.module.scss';
 
 export default function PrivacyPolicy() {
   return (
-    <div className={styles.Section}>
+    <div className={styles.Section} id="privacy_policy">
       <div className={styles.Title}>Privacy Policy</div>
       <div className={styles.Description}>
         <p>

--- a/src/app/components/TermsContainer/TermsOfUse/index.tsx
+++ b/src/app/components/TermsContainer/TermsOfUse/index.tsx
@@ -2,7 +2,7 @@ import styles from './TermsOfUse.module.scss';
 
 export default function TermsOfUse() {
   return (
-    <div className={styles.Section}>
+    <div className={styles.Section} id="terms_of_use">
       <div className={styles.Title}>Terms of Use</div>
       <div className={styles.Description}>
         <p>

--- a/src/app/components/TermsContainer/index.tsx
+++ b/src/app/components/TermsContainer/index.tsx
@@ -4,8 +4,22 @@ import Introduction from './Introduction';
 import PrivacyPolicy from './PrivacyPolicy';
 import TermsOfUse from './TermsOfUse';
 import ContactUs from './ContactUs';
+import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
 
 export default function TermsContainer() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const privacyPolicyElement = document.getElementById('privacy_policy');
+    const termsOfUseElement = document.getElementById('terms_of_use');
+    if (privacyPolicyElement && termsOfUseElement && location.hash.length > 0) {
+      location.hash === '#privacy_policy' &&
+        window.scrollTo(0, privacyPolicyElement.offsetTop - 120);
+      location.hash === '#terms_of_use' && window.scrollTo(0, termsOfUseElement.offsetTop - 120);
+    }
+  }, [location]);
+
   return (
     <LayoutContainer>
       <div className={styles.Container}>

--- a/src/app/components/TermsContainer/index.tsx
+++ b/src/app/components/TermsContainer/index.tsx
@@ -10,6 +10,11 @@ import { useEffect } from 'react';
 export default function TermsContainer() {
   const location = useLocation();
 
+  /**
+   * Handler to scroll to specific element
+   * Checks if location has a hash and scrolls to position based on value
+   * Was initially privacy policy but switched to introduction as we want people to see the beginning of the page
+   */
   useEffect(() => {
     const introductionElement = document.getElementById('introduction');
     const termsOfUseElement = document.getElementById('terms_of_use');

--- a/src/app/components/TermsContainer/index.tsx
+++ b/src/app/components/TermsContainer/index.tsx
@@ -11,11 +11,10 @@ export default function TermsContainer() {
   const location = useLocation();
 
   useEffect(() => {
-    const privacyPolicyElement = document.getElementById('privacy_policy');
+    const introductionElement = document.getElementById('introduction');
     const termsOfUseElement = document.getElementById('terms_of_use');
-    if (privacyPolicyElement && termsOfUseElement && location.hash.length > 0) {
-      location.hash === '#privacy_policy' &&
-        window.scrollTo(0, privacyPolicyElement.offsetTop - 120);
+    if (introductionElement && termsOfUseElement && location.hash.length > 0) {
+      location.hash === '#introduction' && window.scrollTo(0, 0);
       location.hash === '#terms_of_use' && window.scrollTo(0, termsOfUseElement.offsetTop - 120);
     }
   }, [location]);

--- a/src/index.scss
+++ b/src/index.scss
@@ -24,6 +24,7 @@
 html {
   height: 100%;
   background-color: #204824 !important;
+  scroll-behavior: smooth;
 }
 body {
   margin: 0;

--- a/src/index.scss
+++ b/src/index.scss
@@ -36,3 +36,7 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+a {
+  color: $color-default;
+  text-decoration: none;
+}


### PR DESCRIPTION
#### Context
Initially was only going to add a scroll listener for every page change since previous behavior was that it'll redirect but keep the same scroll position. This will look weird so added a listener that will reset the scroll position to the beginning of the page. 

I was feeling a bit wacky so I added a scroll listener to the terms page that will scroll to the specific sections of `introduction` and `terms_of_use`. Wanted to do privacy but settled on introduction as I want people to have a way to see the whole page at least when visiting

![nessie scroll](https://user-images.githubusercontent.com/42207245/174452404-d8e71dc7-5251-47b7-b71c-1457fb86b488.gif)

#### Change
- Add link to home in navbar
- Reset scroll to top when navigating to new location
- Scroll to specific element when navigating
- Add smooth scrolling