### PR TITLE
Use personal cdn

### DIFF
--- a/src/app/components/WorkInProgress/index.tsx
+++ b/src/app/components/WorkInProgress/index.tsx
@@ -4,12 +4,12 @@ export default function WorkInProgress() {
   return (
     <div className={styles.Container}>
       <div>Nothing here yet :)</div>
-      <div>Come back in a couple of weeks!</div>
+      <div>Come back in a couple of weeks! (probably)</div>
       <div className={styles.ImageContainer}>
         <img
           alt="nessie no peace"
           className={styles.Image}
-          src="https://cdn.discordapp.com/attachments/248430185463021569/941367888797896724/nessie_no_peace.jpeg"
+          src="https://vexuas.b-cdn.net/nessie_no_peace.jpeg"
         />
       </div>
     </div>


### PR DESCRIPTION
#### Context
I had an image that was pointing to discord but I'm guessing discord changed their cdn url since it was breaking. I ended up creating a bunny cdn account to store my own images and updated here accordingly

#### Change
- Use personal cdn

![image](https://github.com/user-attachments/assets/9797a9d7-6ccc-4b09-8141-b3703598441d)
