### PR TITLE
Add deployment workflow

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,25 @@
+alerts:
+- rule: DEPLOYMENT_FAILED
+- rule: DOMAIN_FAILED
+domains:
+- domain: nessie.moe
+  type: PRIMARY
+  zone: nessie.moe
+ingress:
+  rules:
+  - component:
+      name: nessie-web
+    match:
+      path:
+        prefix: /
+name: nessie-web
+region: sgp
+static_sites:
+- build_command: yarn build
+  catchall_document: index.html
+  environment_slug: node-js
+  github:
+    branch: develop
+    repo: vexuas/nessie-web
+  name: nessie-web
+  source_dir: /

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,25 +1,29 @@
 alerts:
-- rule: DEPLOYMENT_FAILED
-- rule: DOMAIN_FAILED
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
 domains:
-- domain: nessie.moe
-  type: PRIMARY
-  zone: nessie.moe
+  - domain: nessie.moe
+    type: PRIMARY
+    zone: nessie.moe
 ingress:
   rules:
-  - component:
-      name: nessie-web
-    match:
-      path:
-        prefix: /
+    - component:
+        name: nessie-web
+      match:
+        path:
+          prefix: /
 name: nessie-web
 region: sgp
 static_sites:
-- build_command: yarn build
-  catchall_document: index.html
-  environment_slug: node-js
-  github:
-    branch: develop
-    repo: vexuas/nessie-web
-  name: nessie-web
-  source_dir: /
+  - build_command: |
+      corepack enable &&
+      corepack prepare pnpm@10.12.1 --activate &&
+      pnpm install &&
+      pnpm run build
+    catchall_document: index.html
+    environment_slug: node-js
+    github:
+      branch: develop
+      repo: vexuas/nessie-web
+    name: nessie-web
+    source_dir: /

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,3 +15,12 @@ jobs:
         uses: digitalocean/app_action/deploy@v2
         with:
           token: ${{ secrets.DO_ADMIN_API_ACCESS_TOKEN }}
+
+      - name: Send notification to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_NOTIFICATION_WEBHOOK }}
+          DISCORD_USERNAME: 'Nessie-Web Release Notification'
+          DISCORD_AVATAR: 'https://cdn.vexuas.com/nessie/nessie_no_peace.jpeg'
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: 'Successfully deployed `${{ github.ref_name }}` to production'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,58 +1,17 @@
 name: deploy/prod
 
 on:
-  pull_request:
-  push:
-    branches:
-      - develop
+  release:
+    types: [published]
 
 jobs:
-  test:
-    name: preview
+  deploy-app:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Deploy the app
-        id: deploy
         uses: digitalocean/app_action/deploy@v2
         with:
-          deploy_pr_preview: 'true'
           token: ${{ secrets.DO_ADMIN_API_ACCESS_TOKEN }}
-      - uses: actions/github-script@v7
-        env:
-          BUILD_LOGS: ${{ steps.deploy.outputs.build_logs }}
-          DEPLOY_LOGS: ${{ steps.deploy.outputs.deploy_logs }}
-        with:
-          script: |
-            const { BUILD_LOGS, DEPLOY_LOGS } = process.env
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🚀🚀🚀 The app was successfully deployed at ${{ fromJson(steps.deploy.outputs.app).live_url }}. [1]`
-            })
-      - uses: actions/github-script@v7
-        if: failure()
-        with:
-          script: |
-            const { BUILD_LOGS, DEPLOY_LOGS } = process.env
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `The app failed to be deployed. Logs can be found [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-              ## Logs
-              <details>
-              <summary>Build logs</summary> [2]
-              \`\\
-              ${BUILD_LOGS}
-              \`\\
-              </details>
-              <details>
-              <summary>Deploy logs</summary> [3]
-              \`\\
-              ${DEPLOY_LOGS}
-              \`\\
-              </details>`
-            })

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,57 @@
+name: deploy/prod
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+jobs:
+  test:
+    name: preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Deploy the app
+        id: deploy
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          deploy_pr_preview: 'true'
+          token: ${{ secrets.DO_ADMIN_API_ACCESS_TOKEN }}
+      - uses: actions/github-script@v7
+        env:
+          BUILD_LOGS: ${{ steps.deploy.outputs.build_logs }}
+          DEPLOY_LOGS: ${{ steps.deploy.outputs.deploy_logs }}
+        with:
+          script: |
+            const { BUILD_LOGS, DEPLOY_LOGS } = process.env
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀🚀🚀 The app was successfully deployed at ${{ fromJson(steps.deploy.outputs.app).live_url }}. [1]`
+            })
+      - uses: actions/github-script@v7
+        if: failure()
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `The app failed to be deployed. Logs can be found [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+              ## Logs
+              <details>
+              <summary>Build logs</summary> [2]
+              \`\\
+              ${BUILD_LOGS}
+              \`\\
+              </details>
+              <details>
+              <summary>Deploy logs</summary> [3]
+              \`\\
+              ${DEPLOY_LOGS}
+              \`\\
+              </details>`
+            })

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -36,6 +36,7 @@ jobs:
         if: failure()
         with:
           script: |
+            const { BUILD_LOGS, DEPLOY_LOGS } = process.env
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
#### Context
Historically, I've been using DigitalOcean's App platform for this project's deployment needs. However when I tried deploying with the latest pnpm and vite changes, it suffered a build error. I initially thought it was DO not supporting pnpm since the error mentioned it couldn't find it as well as googling it showed that pnpm wasn't historically allowing it. This made me want to try to manually deploy this through DigitalOcean's Spaces instead where I upload the project's build and it hosting it as a static website.

This led me through a rabbit hole of making this possible since again DO does not support this right out of the bat as opposed to how AWS does it. I found this [one comment ](https://www.digitalocean.com/community/questions/app-platform-build-with-pnpm-command-possible) from DO support mentioning using the s3 API to update the bucket's configuration. This got me pretty far and I'm sure it would work albeit probably unable to change the website's url. I ended up giving up on that and pretty quickly after realising that DO does support pnpm now in their App platform 🫠 

In the end, I opted to stick with that service but make it so it's through a dedicated CI workflow. I've added a deployment workflow in this PR as well as the app spec for digital ocean to make use during build.

#### Change
- Create deployment file
- Create app.yml
