### PR TITLE
Add actual servers as logos

### DIFF
--- a/src/app/components/HomeContainer/Logos/Logos.module.scss
+++ b/src/app/components/HomeContainer/Logos/Logos.module.scss
@@ -56,8 +56,9 @@
     width: calc(100% - 48px * 2);
     padding: 0 48px;
   }
-  .Logo:nth-last-child(-n + 2) {
-    display: none;
+
+  .Logos {
+    width: 200px;
   }
 }
 @include mixins.breakpoint(tablet) {
@@ -65,7 +66,13 @@
     width: calc(100% - 48px * 2);
     padding: 0 48px;
   }
-  .Logo:nth-last-child(-n + 2) {
-    display: none;
+
+  .Logos {
+    width: 500px;
+  }
+}
+@include mixins.breakpoint(desktop) {
+  .Logos {
+    width: 600px;
   }
 }

--- a/src/app/components/HomeContainer/Logos/Logos.module.scss
+++ b/src/app/components/HomeContainer/Logos/Logos.module.scss
@@ -1,4 +1,5 @@
 @use '../../../../assets/styles/mixins.scss' as mixins;
+@use '../../../../assets/styles/variables.scss' as variables;
 
 .Container {
   display: flex;
@@ -26,6 +27,7 @@
 
 .Logos {
   width: 800px;
+  height: 150px;
 
   :global(.swiper-wrapper) {
     transition-timing-function: linear;
@@ -35,8 +37,14 @@
 .Logo {
   width: 100px;
   height: 100px;
+  border: 2px solid variables.$color-default;
   border-radius: 100px;
   margin-right: 38px;
+  box-shadow: rgba(0, 0, 0, 0.17) 0px -23px 25px 0px inset,
+    rgba(0, 0, 0, 0.15) 0px -36px 30px 0px inset, rgba(0, 0, 0, 0.1) 0px -79px 40px 0px inset,
+    rgba(0, 0, 0, 0.06) 0px 2px 1px, rgba(0, 0, 0, 0.09) 0px 4px 2px,
+    rgba(0, 0, 0, 0.09) 0px 8px 4px, rgba(0, 0, 0, 0.09) 0px 16px 8px,
+    rgba(0, 0, 0, 0.09) 0px 32px 16px;
 
   &:last-child {
     margin-right: 0;

--- a/src/app/components/HomeContainer/Logos/Logos.module.scss
+++ b/src/app/components/HomeContainer/Logos/Logos.module.scss
@@ -16,6 +16,14 @@
   text-align: center;
 }
 
+.Users {
+  font-weight: 600;
+}
+
+.Servers {
+  font-weight: 600;
+}
+
 .Logos {
   width: 800px;
 

--- a/src/app/components/HomeContainer/Logos/Logos.module.scss
+++ b/src/app/components/HomeContainer/Logos/Logos.module.scss
@@ -37,7 +37,7 @@
 .Logo {
   width: 100px;
   height: 100px;
-  border: 2px solid variables.$color-default;
+  border: 3px solid variables.$color-default;
   border-radius: 100px;
   margin-right: 38px;
   box-shadow: rgba(0, 0, 0, 0.17) 0px -23px 25px 0px inset,

--- a/src/app/components/HomeContainer/Logos/index.test.tsx
+++ b/src/app/components/HomeContainer/Logos/index.test.tsx
@@ -3,10 +3,12 @@ import Logos from '.';
 
 const mockLogos = [
   {
+    id: 1,
     name: 'Test',
     src: 'https://via.placeholder.com/150',
   },
   {
+    id: 2,
     name: 'Test',
     src: 'https://via.placeholder.com/150',
   },

--- a/src/app/components/HomeContainer/Logos/index.test.tsx
+++ b/src/app/components/HomeContainer/Logos/index.test.tsx
@@ -1,9 +1,31 @@
 import { render, screen } from '@testing-library/react';
 import Logos from '.';
 
+const mockLogos = [
+  {
+    name: 'Test',
+    src: 'https://via.placeholder.com/150',
+  },
+  {
+    name: 'Test',
+    src: 'https://via.placeholder.com/150',
+  },
+];
+
 test('renders', () => {
-  render(<Logos />);
+  render(<Logos logos={[]} noOfUsers="" noOfServers="" />);
 
   expect(screen.getByTestId('Logos')).toBeInTheDocument();
-  expect(screen.getAllByTestId('Logo')).toHaveLength(12);
+  expect(screen.queryByTestId('Logos__logo')).not.toBeInTheDocument();
+});
+test('displays the correct number of users and servers', () => {
+  render(<Logos logos={[]} noOfUsers="130,000" noOfServers="1400" />);
+
+  expect(screen.getByTestId('Logos__users')).toHaveTextContent('130,000');
+  expect(screen.getByTestId('Logos__servers')).toHaveTextContent('1400+');
+});
+test('displays the correct number of logos', () => {
+  render(<Logos logos={mockLogos} noOfUsers="130,000" noOfServers="1400" />);
+
+  expect(screen.getAllByTestId('Logos__logo')).toHaveLength(mockLogos.length);
 });

--- a/src/app/components/HomeContainer/Logos/index.tsx
+++ b/src/app/components/HomeContainer/Logos/index.tsx
@@ -8,13 +8,16 @@ import 'swiper/css/autoplay';
 // TODO: Add carousel functionality
 
 interface Props {
-  logos: { name: string; src: string }[];
+  logos: { id: number; name: string; src: string }[];
   noOfUsers: string;
   noOfServers: string;
 }
 
 export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
   const breakPoints = {
+    0: {
+      slidesPerView: 2,
+    },
     600: {
       slidesPerView: 4,
     },
@@ -25,9 +28,9 @@ export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
       slidesPerView: 6,
     },
   };
-  const t_logos = logos.map((logo, index) => {
+  const t_logos = logos.map((logo) => {
     return (
-      <SwiperSlide key={index}>
+      <SwiperSlide key={logo.id}>
         <img className={styles.Logo} data-testid="Logos__logo" src={logo.src} alt={logo.name} />
       </SwiperSlide>
     );

--- a/src/app/components/HomeContainer/Logos/index.tsx
+++ b/src/app/components/HomeContainer/Logos/index.tsx
@@ -28,7 +28,7 @@ export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
   const t_logos = logos.map((logo, index) => {
     return (
       <SwiperSlide key={index}>
-        <img className={styles.Logo} data-testid="Logo" src={logo.src} alt={logo.name} />
+        <img className={styles.Logo} data-testid="Logos__logo" src={logo.src} alt={logo.name} />
       </SwiperSlide>
     );
   });
@@ -36,8 +36,15 @@ export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
   return (
     <div className={styles.Container} data-testid="Logos">
       <div className={styles.Title}>
-        Join over <span className={styles.Users}>{noOfUsers}</span> users in{' '}
-        <span className={styles.Servers}>{noOfServers}+</span> servers using Nessie
+        Join over{' '}
+        <span className={styles.Users} data-testid="Logos__users">
+          {noOfUsers}
+        </span>{' '}
+        users in{' '}
+        <span className={styles.Servers} data-testid="Logos__servers">
+          {noOfServers}+
+        </span>{' '}
+        servers using Nessie
       </div>
       <Swiper
         freeMode

--- a/src/app/components/HomeContainer/Logos/index.tsx
+++ b/src/app/components/HomeContainer/Logos/index.tsx
@@ -6,23 +6,15 @@ import 'swiper/css/autoplay';
 
 // TODO: Upload server logos to cdn and hardcode them here
 // TODO: Add carousel functionality
-export default function Logos() {
-  const MOCK_LOGOS: string[] = [
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-  ];
 
-  const t_logos = MOCK_LOGOS.map((logo, index) => {
+interface Props {
+  logos: string[];
+  noOfUsers: string;
+  noOfServers: string;
+}
+
+export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
+  const t_logos = logos.map((logo, index) => {
     return (
       <SwiperSlide key={index}>
         <img className={styles.Logo} data-testid="Logo" src={logo} alt="logo" />
@@ -32,7 +24,10 @@ export default function Logos() {
 
   return (
     <div className={styles.Container} data-testid="Logos">
-      <div className={styles.Title}>Join 123456 users in 2000 servers using Nessie</div>
+      <div className={styles.Title}>
+        Join over <span className={styles.Users}>{noOfUsers}</span> users in{' '}
+        <span className={styles.Servers}>{noOfServers}+</span> servers using Nessie
+      </div>
       <Swiper
         freeMode
         loop

--- a/src/app/components/HomeContainer/Logos/index.tsx
+++ b/src/app/components/HomeContainer/Logos/index.tsx
@@ -35,7 +35,7 @@ export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
         modules={[Autoplay]}
         className={styles.Logos}
         slidesPerView={6}
-        speed={5000}
+        speed={7500}
       >
         {t_logos}
       </Swiper>

--- a/src/app/components/HomeContainer/Logos/index.tsx
+++ b/src/app/components/HomeContainer/Logos/index.tsx
@@ -14,6 +14,17 @@ interface Props {
 }
 
 export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
+  const breakPoints = {
+    600: {
+      slidesPerView: 4,
+    },
+    768: {
+      slidesPerView: 4,
+    },
+    1024: {
+      slidesPerView: 6,
+    },
+  };
   const t_logos = logos.map((logo, index) => {
     return (
       <SwiperSlide key={index}>
@@ -32,9 +43,9 @@ export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
         freeMode
         loop
         autoplay={{ delay: 0, disableOnInteraction: false }}
+        breakpoints={breakPoints}
         modules={[Autoplay]}
         className={styles.Logos}
-        slidesPerView={6}
         speed={7500}
       >
         {t_logos}

--- a/src/app/components/HomeContainer/Logos/index.tsx
+++ b/src/app/components/HomeContainer/Logos/index.tsx
@@ -8,7 +8,7 @@ import 'swiper/css/autoplay';
 // TODO: Add carousel functionality
 
 interface Props {
-  logos: string[];
+  logos: { name: string; src: string }[];
   noOfUsers: string;
   noOfServers: string;
 }
@@ -17,7 +17,7 @@ export default function Logos({ logos, noOfUsers, noOfServers }: Props) {
   const t_logos = logos.map((logo, index) => {
     return (
       <SwiperSlide key={index}>
-        <img className={styles.Logo} data-testid="Logo" src={logo} alt="logo" />
+        <img className={styles.Logo} data-testid="Logo" src={logo.src} alt={logo.name} />
       </SwiperSlide>
     );
   });

--- a/src/app/components/HomeContainer/index.tsx
+++ b/src/app/components/HomeContainer/index.tsx
@@ -2,10 +2,27 @@ import Hero from './Hero';
 import Logos from './Logos';
 
 export default function HomeContainer() {
+  const MOCK_LOGOS: string[] = [
+    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
+    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
+    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
+    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
+    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
+    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
+    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
+    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
+    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
+    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
+    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
+    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
+  ];
+  const noOfUsers = '130,000';
+  const noOfServers = '1400';
+
   return (
     <div data-testid="HomeContainer">
       <Hero />
-      <Logos />
+      <Logos logos={MOCK_LOGOS} noOfUsers={noOfUsers} noOfServers={noOfServers} />
     </div>
   );
 }

--- a/src/app/components/HomeContainer/index.tsx
+++ b/src/app/components/HomeContainer/index.tsx
@@ -1,9 +1,13 @@
+import { useMemo } from 'react';
 import { SERVER_LOGOS } from '../../../utils/constants';
 import Hero from './Hero';
 import Logos from './Logos';
 
 export default function HomeContainer() {
-  const logos: { name: string; src: string }[] = [...SERVER_LOGOS].sort(() => Math.random() - 0.5); // Shuffle the position of logos on every render for fun
+  const logos: { name: string; src: string }[] = useMemo(() => {
+    return [...SERVER_LOGOS].sort(() => Math.random() - 0.5); // Shuffle the position of logos for fun
+  }, [SERVER_LOGOS]);
+
   const noOfUsers: string = '130,000';
   const noOfServers: string = '1400';
 

--- a/src/app/components/HomeContainer/index.tsx
+++ b/src/app/components/HomeContainer/index.tsx
@@ -4,7 +4,7 @@ import Hero from './Hero';
 import Logos from './Logos';
 
 export default function HomeContainer() {
-  const logos: { name: string; src: string }[] = useMemo(() => {
+  const logos: { id: number; name: string; src: string }[] = useMemo(() => {
     return [...SERVER_LOGOS].sort(() => Math.random() - 0.5); // Shuffle the position of logos for fun
   }, [SERVER_LOGOS]);
 

--- a/src/app/components/HomeContainer/index.tsx
+++ b/src/app/components/HomeContainer/index.tsx
@@ -1,28 +1,15 @@
+import { SERVER_LOGOS } from '../../../utils/constants';
 import Hero from './Hero';
 import Logos from './Logos';
 
 export default function HomeContainer() {
-  const MOCK_LOGOS: string[] = [
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-    'https://cdn.vexuas.com/Wallpapers/you_cute.jpg',
-    'https://cdn.vexuas.com/Wallpapers/maki_full.jpg',
-  ];
   const noOfUsers = '130,000';
   const noOfServers = '1400';
 
   return (
     <div data-testid="HomeContainer">
       <Hero />
-      <Logos logos={MOCK_LOGOS} noOfUsers={noOfUsers} noOfServers={noOfServers} />
+      <Logos logos={SERVER_LOGOS} noOfUsers={noOfUsers} noOfServers={noOfServers} />
     </div>
   );
 }

--- a/src/app/components/HomeContainer/index.tsx
+++ b/src/app/components/HomeContainer/index.tsx
@@ -3,13 +3,14 @@ import Hero from './Hero';
 import Logos from './Logos';
 
 export default function HomeContainer() {
-  const noOfUsers = '130,000';
-  const noOfServers = '1400';
+  const logos: { name: string; src: string }[] = [...SERVER_LOGOS].sort(() => Math.random() - 0.5); // Shuffle the position of logos on every render for fun
+  const noOfUsers: string = '130,000';
+  const noOfServers: string = '1400';
 
   return (
     <div data-testid="HomeContainer">
       <Hero />
-      <Logos logos={SERVER_LOGOS} noOfUsers={noOfUsers} noOfServers={noOfServers} />
+      <Logos logos={logos} noOfUsers={noOfUsers} noOfServers={noOfServers} />
     </div>
   );
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,17 @@
 export const DISCORD_INVITE_LINK =
   'https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot';
+
+export const SERVER_LOGOS = [
+  'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8.webp',
+  'https://cdn.vexuas.com/nessie/servers/%E1%84%8B%E1%85%A6%E1%84%91%E1%85%A6%E1%86%A8%E1%84%87%E1%85%A1%E1%86%BC.webp',
+  'https://cdn.vexuas.com/nessie/servers/dokuwaki.webp',
+  'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A7%E1%86%BC%E1%84%85%E1%85%A9%E1%84%83%E1%85%A1%E1%86%BC.webp',
+  'https://cdn.vexuas.com/nessie/servers/%E1%84%88%E1%85%A1%E1%86%AB%E1%84%89%E1%85%B3%E1%84%80%E1%85%A9%E1%86%AF%E1%84%85%E1%85%A6%E1%86%B7.gif',
+  'https://cdn.vexuas.com/nessie/servers/Apex_Vanguard.webp',
+  'https://cdn.vexuas.com/nessie/servers/the_fire_nation.webp',
+  'https://cdn.vexuas.com/nessie/servers/%E1%84%87%E1%85%B3%E1%84%87%E1%85%AE%E1%86%BC%E1%84%80%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%A9%E1%86%B8%E1%84%89%E1%85%A5%E1%84%87%E1%85%A5%20.gif',
+  'https://cdn.vexuas.com/nessie/servers/Discord.webp',
+  'https://cdn.vexuas.com/nessie/servers/Game_Lounge.webp',
+  'https://cdn.vexuas.com/nessie/servers/Lockers.webp',
+  'https://cdn.vexuas.com/nessie/servers/Black_Jack.webp',
+];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,17 +1,53 @@
-export const DISCORD_INVITE_LINK =
+export const DISCORD_INVITE_LINK: string =
   'https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot';
 
-export const SERVER_LOGOS = [
-  'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8.webp',
-  'https://cdn.vexuas.com/nessie/servers/%E1%84%8B%E1%85%A6%E1%84%91%E1%85%A6%E1%86%A8%E1%84%87%E1%85%A1%E1%86%BC.webp',
-  'https://cdn.vexuas.com/nessie/servers/dokuwaki.webp',
-  'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A7%E1%86%BC%E1%84%85%E1%85%A9%E1%84%83%E1%85%A1%E1%86%BC.webp',
-  'https://cdn.vexuas.com/nessie/servers/%E1%84%88%E1%85%A1%E1%86%AB%E1%84%89%E1%85%B3%E1%84%80%E1%85%A9%E1%86%AF%E1%84%85%E1%85%A6%E1%86%B7.gif',
-  'https://cdn.vexuas.com/nessie/servers/Apex_Vanguard.webp',
-  'https://cdn.vexuas.com/nessie/servers/the_fire_nation.webp',
-  'https://cdn.vexuas.com/nessie/servers/%E1%84%87%E1%85%B3%E1%84%87%E1%85%AE%E1%86%BC%E1%84%80%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%A9%E1%86%B8%E1%84%89%E1%85%A5%E1%84%87%E1%85%A5%20.gif',
-  'https://cdn.vexuas.com/nessie/servers/Discord.webp',
-  'https://cdn.vexuas.com/nessie/servers/Game_Lounge.webp',
-  'https://cdn.vexuas.com/nessie/servers/Lockers.webp',
-  'https://cdn.vexuas.com/nessie/servers/Black_Jack.webp',
+export const SERVER_LOGOS: { name: string; src: string }[] = [
+  {
+    name: '게임클럽',
+    src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8.webp',
+  },
+  {
+    name: '에펙방',
+    src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%8B%E1%85%A6%E1%84%91%E1%85%A6%E1%86%A8%E1%84%87%E1%85%A1%E1%86%BC.webp',
+  },
+  {
+    name: 'Dokuwaki',
+    src: 'https://cdn.vexuas.com/nessie/servers/dokuwaki.webp',
+  },
+  {
+    name: '경로당',
+    src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A7%E1%86%BC%E1%84%85%E1%85%A9%E1%84%83%E1%85%A1%E1%86%BC.webp',
+  },
+  {
+    name: '빤스골렘',
+    src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%88%E1%85%A1%E1%86%AB%E1%84%89%E1%85%B3%E1%84%80%E1%85%A9%E1%86%AF%E1%84%85%E1%85%A6%E1%86%B7.gif',
+  },
+  {
+    name: 'The Fire Nation',
+    src: 'https://cdn.vexuas.com/nessie/servers/the_fire_nation.webp',
+  },
+  {
+    name: '브붕글옵서버',
+    src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%87%E1%85%B3%E1%84%87%E1%85%AE%E1%86%BC%E1%84%80%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%A9%E1%86%B8%E1%84%89%E1%85%A5%E1%84%87%E1%85%A5%20.gif',
+  },
+  {
+    name: 'Discord',
+    src: 'https://cdn.vexuas.com/nessie/servers/Discord.webp',
+  },
+  {
+    name: 'Game Lounge',
+    src: 'https://cdn.vexuas.com/nessie/servers/Game_Lounge.webp',
+  },
+  {
+    name: 'Lockers',
+    src: 'https://cdn.vexuas.com/nessie/servers/Lockers.webp',
+  },
+  {
+    name: 'Black Jack',
+    src: 'https://cdn.vexuas.com/nessie/servers/Black_Jack.webp',
+  },
+  {
+    name: 'Millenium Squad',
+    src: 'https://cdn.vexuas.com/nessie/servers/Millenium_Squad.webp',
+  },
 ];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,52 +1,64 @@
 export const DISCORD_INVITE_LINK: string =
   'https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot';
 
-export const SERVER_LOGOS: { name: string; src: string }[] = [
+export const SERVER_LOGOS: { id: number; name: string; src: string }[] = [
   {
+    id: 1,
     name: '게임클럽',
     src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8.webp',
   },
   {
+    id: 2,
     name: '에펙방',
     src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%8B%E1%85%A6%E1%84%91%E1%85%A6%E1%86%A8%E1%84%87%E1%85%A1%E1%86%BC.webp',
   },
   {
+    id: 3,
     name: 'Dokuwaki',
     src: 'https://cdn.vexuas.com/nessie/servers/dokuwaki.webp',
   },
   {
+    id: 4,
     name: '경로당',
     src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%80%E1%85%A7%E1%86%BC%E1%84%85%E1%85%A9%E1%84%83%E1%85%A1%E1%86%BC.webp',
   },
   {
+    id: 5,
     name: '빤스골렘',
     src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%88%E1%85%A1%E1%86%AB%E1%84%89%E1%85%B3%E1%84%80%E1%85%A9%E1%86%AF%E1%84%85%E1%85%A6%E1%86%B7.gif',
   },
   {
+    id: 6,
     name: 'The Fire Nation',
     src: 'https://cdn.vexuas.com/nessie/servers/the_fire_nation.webp',
   },
   {
+    id: 7,
     name: '브붕글옵서버',
     src: 'https://cdn.vexuas.com/nessie/servers/%E1%84%87%E1%85%B3%E1%84%87%E1%85%AE%E1%86%BC%E1%84%80%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%A9%E1%86%B8%E1%84%89%E1%85%A5%E1%84%87%E1%85%A5%20.gif',
   },
   {
+    id: 8,
     name: 'Discord',
     src: 'https://cdn.vexuas.com/nessie/servers/Discord.webp',
   },
   {
+    id: 9,
     name: 'Game Lounge',
     src: 'https://cdn.vexuas.com/nessie/servers/Game_Lounge.webp',
   },
   {
+    id: 10,
     name: 'Lockers',
     src: 'https://cdn.vexuas.com/nessie/servers/Lockers.webp',
   },
   {
+    id: 11,
     name: 'Black Jack',
     src: 'https://cdn.vexuas.com/nessie/servers/Black_Jack.webp',
   },
   {
+    id: 12,
     name: 'Millenium Squad',
     src: 'https://cdn.vexuas.com/nessie/servers/Millenium_Squad.webp',
   },


### PR DESCRIPTION
#### Context
In this PR, I've replaced the placeholder data of logos to actual servers. I took the most active servers that have been using Nessie through Mixpanel and uploaded their server images to my DigitalOcean cdn and linked them here. From the comments in #34, I've also added responsive breakpoints

https://github.com/user-attachments/assets/99080844-85a9-421b-a352-51a9f44a5097

#### Change
- Pass down logos and server and count from home container
- Add actual server logos
- Add box shadow to logos
- Change schema of logos
- Slow down swiper speed
- Add responsive breakpoints
- Add tests