### PR TITLE
Fix Logos responsive design

### DIFF
--- a/src/app/components/HomeContainer/Logos/Logos.module.scss
+++ b/src/app/components/HomeContainer/Logos/Logos.module.scss
@@ -58,7 +58,7 @@
   }
 
   .Logos {
-    width: 200px;
+    width: 250px;
   }
 }
 @include mixins.breakpoint(tablet) {


### PR DESCRIPTION
#### Context
Screens below 300px is causing the Logos carousel to be squished. Just made the width of its container to be slightly bigger

Issue:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/ca954d6a-3a63-448d-adb3-cb3ca2c0d6c8" />

Fix:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/25dfd61b-6e0c-434b-af13-c0a011bf74ff" />

#### Change
- Make Logos width bigger