### PR TITLE
Release/2025 07 06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v0.4.5 (Sun Jul 06 2025)
+
+#### 🔧 Tweaks
+
+- Add missing docker container login step in deployment [#42](https://github.com/vexuas/nessie-web/pull/42) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2025 07 06 [#41](https://github.com/vexuas/nessie-web/pull/41) ([@vexuas](https://github.com/vexuas))
+
+#### Authors: 1
+
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v0.4.4 (Sun Jul 06 2025)
 
 #### 🔧 Tweaks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nessie-web",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "dependencies": {
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.0.1",


### PR DESCRIPTION
# v0.4.5 (Sun Jul 06 2025)

#### 🔧 Tweaks

- Add missing docker container login step in deployment [#42](https://github.com/vexuas/nessie-web/pull/42) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2025 07 06 [#41](https://github.com/vexuas/nessie-web/pull/41) ([@vexuas](https://github.com/vexuas))

#### Authors: 1

- Gabriel R ([@vexuas](https://github.com/vexuas))
